### PR TITLE
[WIP] Additional features

### DIFF
--- a/html-to-hiccup.el
+++ b/html-to-hiccup.el
@@ -53,18 +53,16 @@
 
 (defun html-to-hiccup--sexp-to-hiccup-tag (elem)
   "Generate Hiccup for a HTML element tag + id/class shorthands."
-  (let ((attrs (cadr elem)))
+  (let ((attrs (cadr elem))
+        (tag (symbol-name (car elem))))
     (concat ":" (symbol-name (car elem))
             (when-let ((id (cdr (assoc 'id attrs))))
-              (concat "#" id))
-            (when-let ((class (cdr (assoc 'class attrs))))
-              (concat "." (s-replace " " "." (s-trim class)))))))
+              (concat "#" id)))))
 
 (defun html-to-hiccup--sexp-to-hiccup-attrs (attrs)
   "Generate a Hiccup attributes map."
   (if-let ((attrs (--map (format ":%s %S" (car it) (cdr it))
-                         (assq-delete-all 'class
-                          (assq-delete-all 'id attrs)))))
+                          (assq-delete-all 'id attrs))))
       (concat " {" (s-join " " attrs) "}")))
 
 (defun html-to-hiccup--sexp-to-hiccup-children (cs)
@@ -77,11 +75,13 @@
 
 (defun html-to-hiccup--sexp-to-hiccup (html-sexp)
   "Turn a html-sexp (as returned by libxml-parse-*) into a Hiccup element."
-  (concat "["
-          (html-to-hiccup--sexp-to-hiccup-tag html-sexp)
-          (html-to-hiccup--sexp-to-hiccup-attrs (cadr html-sexp))
-          (html-to-hiccup--sexp-to-hiccup-children (cddr html-sexp))
-          "]"))
+  (concat
+   (if (equal (symbol-name (car html-sexp)) "comment")
+       "#_[" "[")
+   (html-to-hiccup--sexp-to-hiccup-tag html-sexp)
+   (html-to-hiccup--sexp-to-hiccup-attrs (cadr html-sexp))
+   (html-to-hiccup--sexp-to-hiccup-children (cddr html-sexp))
+   "]"))
 
 ;;;###autoload
 (defun html-to-hiccup-convert-region (start end &optional bodytags)


### PR DESCRIPTION
This PR adds two additional features
- [x] Put html classes in an explicit hiccup map eg: `<p class="mt-2 pt-2">hello</p>` converts to `[:p {:class "mt-2 pt-2"} "hello"]` instead of `[:p.mt-2.pt-2 "hello"]`
- [ ] Make the above configurable with an optional param
- [x] Handle html comments: comments will show up as `#_[:comment "this is a comment"]` instead of `[:comment "this is a comment"]` (`:comment` gets interpreted as a `span` in html and without `#_` it ends up getting rendered on the final output)