### PR TITLE
Do not convert class to shorthand notation when it contains `/'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - '**.org'
+  pull_request:
+    paths-ignore:
+      - '**.org'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          # Add more lines like this if you want to test on different Emacs versions.
+          - 27.2
+
+    steps:
+    - name: Set up Emacs
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{matrix.emacs_version}}
+
+    - name: Install Eldev
+      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
+
+    - name: Check out the source code
+      uses: actions/checkout@v2
+
+    - name: Test the project
+      run: |
+        eldev -p -dtT test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Added automatically by `eldev init'.
+/.eldev
+/Eldev-local
+
+*~

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,5 @@
+; -*- mode: emacs-lisp; lexical-binding: t -*-
+
+;; Autodetermined by `eldev init'.
+(eldev-use-package-archive 'melpa)
+

--- a/README.org
+++ b/README.org
@@ -64,6 +64,16 @@ into this
   [:div#thing [:span.important "Enjoy your lemonade"]]
 #+END_SRC
 
+* Tests
+
+You can either run the tests interactively by loading the test file in
+Emacs with ~M-x load-file~ and then ~M-x ert RET t~ (see [[https://www.gnu.org/software/emacs/manual/html_node/ert/Running-Tests-Interactively.html][ERT - running
+tests interactively]]), or from the command line by invoking [[https://github.com/doublep/eldev][Eldev]] as
+
+#+begin_src shell
+  eldev test
+#+end_src
+
 * Attribution
 
 I had an earlier, hacky version of this code lying around before. Jack Rusher

--- a/html-to-hiccup-tests.el
+++ b/html-to-hiccup-tests.el
@@ -1,3 +1,4 @@
+(require 'ert)
 (load-file "html-to-hiccup.el")
 
 (defun set-up-buffer (str keys start end)
@@ -10,7 +11,7 @@
       (set-window-buffer nil (current-buffer))
       (goto-char (point-min))
       (execute-kbd-macro (kbd keys)))
-    (buffer-substring start end)))
+    (buffer-substring start (min end (point-max)))))
 
 
 (defun html-to-hiccup-test-case (html hiccup)
@@ -42,6 +43,17 @@
     </html>"
    "[:html [:body#foo [:h1.header.big \"Yes\"] [:p \"foo\"]]]"))
 
+(ert-deftest html-to-hiccup-class-special-chars-test ()
+  "HTML to Hiccup conversion test"
+  (html-to-hiccup-test-case
+   "<html>
+      <body id=\"foo\">
+        <h1 class=\"max-w-sm w-full sm:w-1/2 lg:w-1/3 py-6 px-3\">Yes</h1>
+        <p>foo</p>
+      </body>
+    </html>"
+   "[:html [:body#foo [:h1 {:class \"max-w-sm w-full sm:w-1/2 lg:w-1/3 py-6 px-3\"} \"Yes\"] [:p \"foo\"]]]"))
+
 (ert-deftest html-to-hiccup-convert-region-attrs-test ()
   "HTML to Hiccup conversion test"
   (html-to-hiccup-test-case
@@ -52,5 +64,3 @@
       </body>
     </html>"
    "[:html [:body [:h1.header.big {:aria-label \"Yes\"} \"Yes\"] [:p {:style \"border: 1px solid black;\" :foo \"bar\"} \"foo\"]]]"))
-
-(ert t)


### PR DESCRIPTION
Hi,

could you please consider patch to prevent generating tag class shorthand notation when a class attribute contains `/`, it creates a `class` attribute instead.

Fixes #10.

A new test has been added to test the same.

I've only done the minimum work required to support `/` in **class** attributes. Possibly there are more class characters that could generate invalid shothands, and the same should be true for **id** shorthands, thus I'm open to improvements if you think a wholistic approach is necessary at this stage. 



I've also bundled in an [Eldev](https://github.com/doublep/eldev) configuration file, so that the test can be run from the command line with proper isolation  (updated readme file), and as a GitHub workflow (using ubuntu latest with 27.2). If you think this is indeed useful but shouldn't be piggie-backed as an secondary item in this PR, I can open a separate one. Likewise,  I can remove the code if you think is too much.

All tests pass on GitHub CI.

Thanks!